### PR TITLE
Refactor variables and controls, improve file dialogs controls checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.ini
 /old*/
 /reserv*/
+/Releas*/

--- a/Libs/AppSettings.ahk
+++ b/Libs/AppSettings.ahk
@@ -8,24 +8,24 @@ RestartApp() {
             Reload
     } else {
         Reload
-    }    
+    }
 }
 
 ValidateAutoStartup() {
 	global AutoStartup, ScriptName
-    
+
     IniRead, AutoStartup, %INI%, App, AutoStartup, %AutoStartup%
-	link := A_Startup . "\" . ScriptName . ".lnk"	    
-	
+	link := A_Startup . "\" . ScriptName . ".lnk"
+
     if AutoStartup {
 		if !FileExist(link) {
 			FileCreateShortcut, %A_ScriptFullPath%, %link%, %A_ScriptDir%
-			TrayTip, %ScriptName%, AutoStartup enabled 
+			TrayTip, %ScriptName%, AutoStartup enabled
 		}
 	} else {
 		if FileExist(link) {
 			FileDelete, %link%
-            TrayTip, %ScriptName%, AutoStartup disabled,, 0x2 
+            TrayTip, %ScriptName%, AutoStartup disabled,, 0x2
 		}
 	}
 }
@@ -33,38 +33,38 @@ ValidateAutoStartup() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ShowAppSettings() {
-;───────────────────────────────────────────────────────────────────────────── 
-    global 
-    
+;─────────────────────────────────────────────────────────────────────────────
+    global
+
     Gui, Font,,%MainFont%
     Gui, Color, %GuiColor%
 
     ; SHORT fIELDS
-    ;				type		coordinates		vVARIABLE  gGOTO							title 
+    ;				type		coordinates		vVARIABLE  gGOTO							title
     Gui, 	Add, 	CheckBox, 	x30 y+10  w200 	vAutoStartup checked%AutoStartup%,          Launch at &system startup
-   
-    Gui, 	Add, 	Text, 		y+20,						                                Open &menu key	
-    Gui, 	Add, 	Edit, 		x120 yp-4 w63 	vMainKey, 							        %MainKey%    
-    Gui, 	Add, 	Text, 		x30,						                                App &restart key	
+
+    Gui, 	Add, 	Text, 		y+20,						                                Open &menu key
+    Gui, 	Add, 	Edit, 		x120 yp-4 w63 	vMainKey, 							        %MainKey%
+    Gui, 	Add, 	Text, 		x30,						                                App &restart key
     Gui, 	Add, 	Edit, 		x120 yp-4 w63 	vRestartKey, 							    %RestartKey%
-      
+
     ; WIDE FIELDS
-    Gui, 	Add, 	Text, 		x30,						                                Restart only in	
-    Gui, 	Add, 	Edit, 		x120 yp-4 w174 	vRestartWhere -Wrap r1, 					%RestartWhere%    
-    Gui, 	Add, 	Text, 		x30,						                                Icon (tray)	
+    Gui, 	Add, 	Text, 		x30,						                                Restart only in
+    Gui, 	Add, 	Edit, 		x120 yp-4 w174 	vRestartWhere -Wrap r1, 					%RestartWhere%
+    Gui, 	Add, 	Text, 		x30,						                                Icon (tray)
     Gui, 	Add, 	Edit, 		x120 yp-4 w174 	vMainIcon -Wrap r1, 						%MainIcon%
-    Gui, 	Add, 	Text, 		x30,						                                Font 
-    Gui, 	Add, 	Edit, 		x120 yp-4 w174 	vMainFont -Wrap r1, 					    %MainFont%  
-    
-    ; hidden default button used for accepting {Enter} to leave GUI	
+    Gui, 	Add, 	Text, 		x30,						                                Font
+    Gui, 	Add, 	Edit, 		x120 yp-4 w174 	vMainFont -Wrap r1, 					    %MainFont%
+
+    ; hidden default button used for accepting {Enter} to leave GUI
     Gui, 	Add, 	Button, 	x30 y+20 w74 	Default  gSaveSettings, 					&OK
     Gui, 	Add, 	Button, 	x+20 w74 		Cancel   gCancel, 							&Cancel
     Gui, 	Add, 	Button, 	x+20 w74 		         gShowDebugMenu, 					&Debug
-    
+
     ; SETUP AND SHOW GUI
     local Xpos := WinX
-    local Ypos := WinY + 100 
+    local Ypos := WinY + 100
     Gui, Show, x%Xpos% y%Ypos%, %ScriptName% settings
-    
-    Return    
+
+    Return
 }

--- a/Libs/AutoSwitch.ahk
+++ b/Libs/AutoSwitch.ahk
@@ -1,5 +1,5 @@
-/* 
-    These options are available in the Paths Menu. 
+/*
+    These options are available in the Paths Menu.
     AutoSwitch() is called each time a dialogue is opened if it is enabled.
     Depends on DialogAction variable, which is bound to each window's FingerPrint.
 */
@@ -16,7 +16,7 @@ AutoSwitch() {
 }
 
 Never() {
-    global 
+    global
     IniWrite, 0, %INI%, Dialogs, %FingerPrint%
     DialogAction := 0
     LastMenuItem := A_ThisMenuItem

--- a/Libs/Debug.ahk
+++ b/Libs/Debug.ahk
@@ -27,7 +27,7 @@ DebugExport() {
         oFile:=""
 
         Msgbox Results exported to:`n`n"%_filename%"
-    } else {                                          ; File could not be initialized    
+    } else {                                          ; File could not be initialized
         Msgbox Cant create %_fileName%
     }
     Return
@@ -44,7 +44,7 @@ ShowDebugMenu() {
     ; Add ControlGetPos [, X, Y, Width, Height, Control, WinTitle, WinText, ExcludeTitle, ExcludeText]
     ; Change dir to ahk
     ; Change name to fingerpringt.csv
-       
+
     global GuiColor
     GUI, Destroy
 
@@ -54,7 +54,7 @@ ShowDebugMenu() {
     ; Loop through controls
     WinGet, ActivecontrolList, ControlList, A
 
-    Loop, Parse, ActivecontrolList, `n 
+    Loop, Parse, ActivecontrolList, `n
     {
         ;Get ID
         ControlGet, _ctrlHandle, Hwnd, , %A_LoopField%, A

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -5,17 +5,15 @@
 */
 
 FeedDialogGENERAL(ByRef _WinID, _path) {
-    global DialogType
 
     WinActivate, ahk_id %_WinID%
     Sleep, 50
 
-    ; Focus Edit1
     ControlFocus Edit1, ahk_id %_WinID%
     WinGet, ActivecontrolList, ControlList, ahk_id %_WinID%
-
+    
     Loop, Parse, ActivecontrolList, `n  
-    {       ; which addressbar and "Enter" controls to use   
+    {       
         if InStr(A_LoopField, "ToolbarWindow32") {
             ControlGet, _ctrlHandle, Hwnd, , %A_LoopField%, ahk_id %_WinID%
             _parentHandle := DllCall("GetParent", "Ptr", _ctrlHandle)
@@ -76,8 +74,6 @@ FeedDialogGENERAL(ByRef _WinID, _path) {
 ;
 FeedDialogSYSLISTVIEW(ByRef _WinID, _path) {
 ;─────────────────────────────────────────────────────────────────────────────
-
-    global DialogType
 
     WinActivate, ahk_id %_WinID%
     ControlGetText _editOld, Edit1, ahk_id %_WinID%

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -65,8 +65,8 @@ FeedDialogGENERAL(ByRef _WinID, _path) {
         }
     } else {
         MsgBox This type of dialog can not be handled (yet).`nPlease report it!
+        LogError(Exception("File dialog", "This type of dialog can not be handled!", "`'Breadcrumb Parent`' and `'msctls_progress32`' controls not found"))
     }    
-
     Return
 }
 

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -114,7 +114,8 @@ FeedDialogSYSLISTVIEW(ByRef _WinID, _path) {
 
     if _pathSet {
         Sleep, 20
-        ControlFocus Edit1, ahk_id %_WinID% ControlSend Edit1, {Enter}, ahk_id %_WinID%
+        ControlFocus Edit1, ahk_id %_WinID% 
+        ControlSend Edit1, {Enter}, ahk_id %_WinID%
 
         ; Restore original filename / make empty in case of previous path
         Sleep, 15
@@ -130,7 +131,6 @@ FeedDialogSYSLISTVIEW(ByRef _WinID, _path) {
                 Break
         }
     }
-
     Return
 }
 
@@ -161,7 +161,8 @@ FeedDialogSYSTREEVIEW(ByRef _WinID, _path) {
 
     if _pathSet {
         Sleep, 20
-        ControlFocus Edit1, ahk_id %_WinID% ControlSend Edit1, {Enter}, ahk_id %_WinID%
+        ControlFocus Edit1, ahk_id %_WinID% 
+        ControlSend Edit1, {Enter}, ahk_id %_WinID%
 
         ; Restore original filename / make empty in case of previous path
         Sleep, 15

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -221,9 +221,6 @@ GetFileDialog(ByRef _DialogID) {
     else if (_SysListView321 and _SysHeader321 and _Edit1)
         Return Func("FeedDialogSYSLISTVIEW")
     
-    else if (_SysTreeView321 and _Edit1)
-        Return Func("FeedDialogSYSTREEVIEW")
-    
     else
         Return false
 }

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -189,30 +189,23 @@ GetFileDialog(ByRef _DialogID) {
 
     ; Detection of a File dialog. Returns FuncObj / false
 
-    ; Only consider this dialog a possible file-dialog when:
-    ; (SysListView321 and ToolbarWindow321) or (DirectUIHWND1 and ToolbarWindow321) controls detected
-    ; First is for Notepad++; second for all other filedialogs
-    ; dw: (SysListView321 and SysHeader321 and Edit1) is for some AutoDesk products (e.g. AutoCAD, Revit, Navisworks)
-    ; which need a delay loop to switch correctly between the dialog components!
-    
     WinGet, _controlList, ControlList, ahk_id %_DialogID%
-
     _SysListView321 := _SysHeader321 := _ToolbarWindow321 := _DirectUIHWND1 := _Edit1 := _SysTreeView321 := 0
     
     Loop, Parse, _controlList, `n 
     {
-    if (A_LoopField == "SysListView321")
-        _SysListView321 := 1
-    else if (A_LoopField == "SysHeader321")
-        _SysHeader321 := 1
-    else if (A_LoopField == "ToolbarWindow321")
-        _ToolbarWindow321 := 1
-    else if (A_LoopField == "DirectUIHWND1")
-        _DirectUIHWND1 := 1
-    else if (A_LoopField == "Edit1")
-        _Edit1 := 1
-    else if (A_LoopField == "SysTreeView321")
-        _SysTreeView321 := 1
+        if (A_LoopField == "SysListView321")
+            _SysListView321 := 1
+        else if (A_LoopField == "SysHeader321")
+            _SysHeader321 := 1
+        else if (A_LoopField == "ToolbarWindow321")
+            _ToolbarWindow321 := 1
+        else if (A_LoopField == "DirectUIHWND1")
+            _DirectUIHWND1 := 1
+        else if (A_LoopField == "Edit1")
+            _Edit1 := 1
+        else if (A_LoopField == "SysTreeView321")
+            _SysTreeView321 := 1
     }
     
     if (_DirectUIHWND1 and _ToolbarWindow321 and _Edit1)

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -100,7 +100,8 @@ FeedDialogSYSLISTVIEW(ByRef _WinID, _path) {
         ControlGet, _Focus, List, Selected, SysListView321, ahk_id %_WinID%
 
     } Until !_Focus
-
+    
+    _pathSet := false
     Loop, 20 {
         Sleep, 10
         ControlSetText, Edit1, %_path%, ahk_id %_WinID%
@@ -146,7 +147,8 @@ FeedDialogSYSTREEVIEW(ByRef _WinID, _path) {
     ; Make sure there exactly one slash at the end.
     _path := RTrim(_path , "\")
     _path := _path . "\"
-
+    _pathSet := false
+    
     Loop, 20 {
         Sleep, 10
         ControlSetText, Edit1, %_path%, ahk_id %_WinID%

--- a/Libs/FileDialogs.ahk
+++ b/Libs/FileDialogs.ahk
@@ -11,9 +11,9 @@ FeedDialogGENERAL(ByRef _WinID, _path) {
 
     ControlFocus Edit1, ahk_id %_WinID%
     WinGet, ActivecontrolList, ControlList, ahk_id %_WinID%
-    
-    Loop, Parse, ActivecontrolList, `n  
-    {       
+
+    Loop, Parse, ActivecontrolList, `n
+    {
         if InStr(A_LoopField, "ToolbarWindow32") {
             ControlGet, _ctrlHandle, Hwnd, , %A_LoopField%, ahk_id %_WinID%
             _parentHandle := DllCall("GetParent", "Ptr", _ctrlHandle)
@@ -66,7 +66,7 @@ FeedDialogGENERAL(ByRef _WinID, _path) {
     } else {
         MsgBox This type of dialog can not be handled (yet).`nPlease report it!
         LogError(Exception("File dialog", "This type of dialog can not be handled!", "`'Breadcrumb Parent`' and `'msctls_progress32`' controls not found"))
-    }    
+    }
     Return
 }
 
@@ -95,26 +95,26 @@ FeedDialogSYSLISTVIEW(ByRef _WinID, _path) {
     ControlSend SysListView321, {Home}, ahk_id %_WinID%
 
     Loop, 100 {
-        Sleep, 10 
+        Sleep, 10
         ControlSend SysListView321, ^{Space}, ahk_id %_WinID%
         ControlGet, _Focus, List, Selected, SysListView321, ahk_id %_WinID%
 
     } Until !_Focus
-    
+
     _pathSet := false
     Loop, 20 {
         Sleep, 10
         ControlSetText, Edit1, %_path%, ahk_id %_WinID%
         ControlGetText, _Edit1, Edit1, ahk_id %_WinID%
 
-        if (_Edit1 == _path)        
+        if (_Edit1 == _path)
             _pathSet := true
 
     } Until _pathSet
 
     if _pathSet {
         Sleep, 20
-        ControlFocus Edit1, ahk_id %_WinID% 
+        ControlFocus Edit1, ahk_id %_WinID%
         ControlSend Edit1, {Enter}, ahk_id %_WinID%
 
         ; Restore original filename / make empty in case of previous path
@@ -148,7 +148,7 @@ FeedDialogSYSTREEVIEW(ByRef _WinID, _path) {
     _path := RTrim(_path , "\")
     _path := _path . "\"
     _pathSet := false
-    
+
     Loop, 20 {
         Sleep, 10
         ControlSetText, Edit1, %_path%, ahk_id %_WinID%
@@ -161,7 +161,7 @@ FeedDialogSYSTREEVIEW(ByRef _WinID, _path) {
 
     if _pathSet {
         Sleep, 20
-        ControlFocus Edit1, ahk_id %_WinID% 
+        ControlFocus Edit1, ahk_id %_WinID%
         ControlSend Edit1, {Enter}, ahk_id %_WinID%
 
         ; Restore original filename / make empty in case of previous path
@@ -170,16 +170,14 @@ FeedDialogSYSTREEVIEW(ByRef _WinID, _path) {
         Sleep, 20
 
         Loop, 5 {
-            ControlSetText, Edit1, %_editOld%, ahk_id %_WinID%             ; set
+            ControlSetText, Edit1, %_editOld%, ahk_id %_WinID%        ; set
             Sleep, 15
             ControlGetText, _editContent, Edit1, ahk_id %_WinID%      ; check
 
             if (_editContent == _editOld)
                 Break
-        
         }
     }
-
     Return
 }
 
@@ -192,8 +190,8 @@ GetFileDialog(ByRef _DialogID) {
 
     WinGet, _controlList, ControlList, ahk_id %_DialogID%
     _SysListView321 := _SysHeader321 := _ToolbarWindow321 := _DirectUIHWND1 := _Edit1 := _SysTreeView321 := 0
-    
-    Loop, Parse, _controlList, `n 
+
+    Loop, Parse, _controlList, `n
     {
         if (A_LoopField == "SysListView321")
             _SysListView321 := 1
@@ -208,19 +206,19 @@ GetFileDialog(ByRef _DialogID) {
         else if (A_LoopField == "SysTreeView321")
             _SysTreeView321 := 1
     }
-    
+
     if (_DirectUIHWND1 and _ToolbarWindow321 and _Edit1)
         Return Func("FeedDialogGENERAL")
-    
+
     else if (_SysListView321 and _ToolbarWindow321 and _Edit1 and _SysHeader321)
         Return Func("FeedDialogSYSTREEVIEW")
-    
+
     else if (_SysListView321 and _ToolbarWindow321 and _Edit1)
         Return Func("FeedDialogSYSLISTVIEW")
-    
+
     else if (_SysListView321 and _SysHeader321 and _Edit1)
         Return Func("FeedDialogSYSLISTVIEW")
-    
+
     else
         Return false
 }

--- a/Libs/GetPaths.ahk
+++ b/Libs/GetPaths.ahk
@@ -1,37 +1,37 @@
 ﻿; Here are the main functions for obtaining paths and interacting with them.
 ; All functions add values to the global paths array.
 
-SelectPath() {    
-    /*     
-        The path is bound to the position of the menu item 
-        and MUST BE ADDED to the array in the same order as the menu item 
+SelectPath() {
+    /*
+        The path is bound to the position of the menu item
+        and MUST BE ADDED to the array in the same order as the menu item
     */
     global
     FileDialog.call(DialogID, paths[A_ThisMenuItemPos])
 }
 
 ShowShortPath(ByRef _path) {
-    /* 
+    /*
         _fullPath is shortened to the last N dirs (DirsCount) starting from the end of the path.
         Dirs are selected as intervals between slashes, excluding them.
-        boundaries = indexes of any slashes \ / in the path: /dir/dir/ 
+        boundaries = indexes of any slashes \ / in the path: /dir/dir/
     */
-    global CutFromEnd, DirsCount, DirNameLength, ShowDriveLetter, PathSeparator, ShortNameIndicator 
-    
+    global CutFromEnd, DirsCount, DirNameLength, ShowDriveLetter, PathSeparator, ShortNameIndicator
+
     ; Return input path if it's really short
     _length := StrLen(_path)
-    if _length < 4                
+    if _length < 4
         Return _path    ; Just drive and slash
-    
-    ; Declare variable to return    
+
+    ; Declare variable to return
     if ShowDriveLetter {
         SplitPath, _path,,,,, _letter
         _shortPath := _letter
     } else {
         _shortPath := ""
     }
-        
-    
+
+
     ; The number of slashes (indexes) is one more than the number of dirs: /f1/f2/ - 2 dirs, 3 slashes
     _maxSlashes := DirsCount + 1
     ; if the number of slashes is less than DirsCount, the array will contain -1
@@ -44,16 +44,16 @@ ShowShortPath(ByRef _path) {
     ;─────────────────────────────────────────────────────────────────────────────
     ;
     ; Parsing the path, looking for the indexes of slashes
-    ;─────────────────────────────────────────────────────────────────────────────    
-    
+    ;─────────────────────────────────────────────────────────────────────────────
+
     _fullPath := _path . "/"         ; Last dir bound
     _length++
     if CutFromEnd {
-        ; Reverse slash search until enough is found 
+        ; Reverse slash search until enough is found
         ; to display the required number of dirs
         _pathIndex    := _length
-        _slashesCount := _maxSlashes 
-        while (_pathIndex >= 3 and _slashesCount >= 1) {     ; 3 is pos of the 1st slash        
+        _slashesCount := _maxSlashes
+        while (_pathIndex >= 3 and _slashesCount >= 1) {     ; 3 is pos of the 1st slash
             _char := SubStr(_fullPath, _pathIndex, 1)
             if (_char == "/" || _char == "\") {
                 _slashIndexes[_slashesCount] := _pathIndex
@@ -63,11 +63,11 @@ ShowShortPath(ByRef _path) {
         }
         if (_slashesCount > _maxSlashes - 2)
             return _path     ; not enough to shorten the path
-        
+
         _shortPath .= ShortNameIndicator     ; An indication that there are more paths after the drive letter
     } else {
-        ; Direct search starting from the pos of the 1st slash 
-        _pathIndex    := 3    
+        ; Direct search starting from the pos of the 1st slash
+        _pathIndex    := 3
         _slashesCount := 1
         while (_pathIndex <= _length and _slashesCount <= _maxSlashes) {
             _char := SubStr(_fullPath, _pathIndex, 1)
@@ -76,44 +76,44 @@ ShowShortPath(ByRef _path) {
                 _slashesCount++
             }
             _pathIndex++
-        } 
+        }
         if (_slashesCount < 3)
             return _path     ; not enough to shorten the path
     }
-    
+
     ;─────────────────────────────────────────────────────────────────────────────
     ;
     ; Parsing the slash indexes and extracting the dir names.
-    ;───────────────────────────────────────────────────────────────────────────── 
+    ;─────────────────────────────────────────────────────────────────────────────
 
     Loop, % DirsCount {
         _left    := _slashIndexes[A_Index]
-        _right   := _slashIndexes[A_Index + 1]    
-        if (_left != -1 and _right != -1) {    
+        _right   := _slashIndexes[A_Index + 1]
+        if (_left != -1 and _right != -1) {
             _left++     ; exclude slash from name
-            
+
             _length     := _right - _left
             _nameLength := Min(_length, DirNameLength)
             _dirName := SubStr(_fullPath, _left, _nameLength)
             _shortPath    .= PathSeparator . _dirName
-            
+
             if (DirNameLength - _length < 0)
                 _shortPath .= ShortNameIndicator
-                
-        } 
+
+        }
     }
     _shortPath .= ShortNameIndicator     ; An indication that there are more paths after the last dir
     Return _shortPath
 }
 
-/* 
-    After execution XYscript waits for a signal and executes FeedXYdata 
-    to get XYdata from XYplorer to Autohotkey. 
-    
+/*
+    After execution XYscript waits for a signal and executes FeedXYdata
+    to get XYdata from XYplorer to Autohotkey.
+
     Alternative variants are provided in Libs/Reserved, including v2
 */
 
-XYscript(ByRef _WinID, ByRef _script) {    
+XYscript(ByRef _WinID, ByRef _script) {
     _size := StrLen(_script)
     if !(A_IsUnicode) {
         VarSetCapacity(_data, _size * 2, 0)
@@ -122,10 +122,10 @@ XYscript(ByRef _WinID, ByRef _script) {
         _data := _script
     }
 
-    VarSetCapacity(COPYDATA, A_PtrSize * 3, 0)       
+    VarSetCapacity(COPYDATA, A_PtrSize * 3, 0)
     NumPut(4194305, COPYDATA, 0, "Ptr")
     NumPut(_size * 2, COPYDATA, A_PtrSize, "UInt")
-    NumPut(&_data, COPYDATA, A_PtrSize * 2, "Ptr")   
+    NumPut(&_data, COPYDATA, A_PtrSize * 2, "Ptr")
 
     Return DllCall("User32.dll\SendMessageW", "Ptr", _WinID, "UInt", 74, "Ptr", 0, "Ptr", &COPYDATA, "Ptr")
 }
@@ -140,95 +140,95 @@ FeedXYdata(_wParam, _lParam) {
 
      Return
 }
-OnMessage(0x4a, "FeedXYdata") 
+OnMessage(0x4a, "FeedXYdata")
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 GetXYpaths(ByRef _WinID) {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
 
     ; Put path(s) to XYdata (the variable is filled in anew each time it is called)
     ; then push to array
     global XYdata, VirtualPath, paths, virtuals
-    
+
     _script =
     ( LTrim Join
         ::
         load('
-        
-            $paths = get("tabs_sf", "|"); 
-            $reals = ""; 
+
+            $paths = get("tabs_sf", "|");
+            $reals = "";
             foreach($path, $paths, "|") {
-                $reals .= "|" . pathreal($path); 
-            } 
-            $reals = replace($reals, "|",,,1,1); 
+                $reals .= "|" . pathreal($path);
+            }
+            $reals = replace($reals, "|",,,1,1);
             copydata %A_ScriptHwnd%, $reals, 2`;
-        
+
         ',,s)`;
     )
     XYscript(_WinID, _script)
 
-    Loop, parse, XYdata, `| 
+    Loop, parse, XYdata, `|
         paths.push(A_LoopField)
-    
+
     if paths and VirtualPath {
         _script = ::copydata %A_ScriptHwnd%, get("tabs_sf", "|"), 2`;
         XYscript(_WinID, _script)
-        Loop, parse, XYdata, `| 
+        Loop, parse, XYdata, `|
             virtuals.push(A_LoopField)
-            
+
     }
 }
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 GetWINpaths(ByRef _WinID) {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
     global paths
-    
+
     for _instance in ComObjCreate("Shell.Application").Windows {
         if (_WinID == _instance.hwnd) {
             _path := _instance.Document.Folder.Self.Path
             if !InStr(_path, "::{")
-                paths.push(_path) 
-        
+                paths.push(_path)
+
         }
     }
-    Return            
+    Return
 }
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 GetTCPaths(_WinID) {
-;───────────────────────────────────────────────────────────────────────────── 
-         
+;─────────────────────────────────────────────────────────────────────────────
+
     global paths
     ; Save clipboard to restore later
     ClipSaved := ClipboardAll
     Clipboard := ""
-        
+
     ; wait a little, or source path may not be captured!
     Sleep, 50
     SendMessage 1075, 2029, 0, , ahk_id %_WinID%    ; CopySrcPathToClip
     Sleep, 50
-    paths.push(clipboard)    
-        
+    paths.push(clipboard)
+
     SendMessage 1075, 2030, 0, , ahk_id %_WinID%    ; CopyTrgPathToClip
     Sleep, 50
-    paths.push(clipboard)     
-    
-    ; Restore    
+    paths.push(clipboard)
+
+    ; Restore
     Clipboard := ClipSaved
     ClipSaved := ""
-    
-    Return    
+
+    Return
 }
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 GetDOPUSPaths(_WinID) {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
     global paths
-    
+
     EnvGet, _temp, TEMP
     _dopusInfo := _temp . "\dopusinfo.xml"
 
@@ -239,47 +239,47 @@ GetDOPUSPaths(_WinID) {
     FileRead, OpusInfo, %_dopusInfo%
     Sleep, 300
     FileDelete, %_dopusInfo%
-    
+
     ; Get active path of this lister (regex instead of XML library)
     RegExMatch(OpusInfo, "mO)^.*lister=\""" . _WinID . "\"".*tab_state=\""1\"".*\>(.*)\<\/path\>$", out)
     _path := out.Value(1)
     paths.push(_path)
-    
+
     ; Get passive path of this lister
     RegExMatch(OpusInfo, "mO)^.*lister=\""" . _WinID . "\"".*tab_state=\""2\"".*\>(.*)\<\/path\>$", out)
     _path := out.Value(1)
     paths.push(_path)
-   
+
     Return
 }
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 GetPaths() {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
 
     ; Update the values after each call
     global paths    := []
     global virtuals := []
-    
+
     global VirtualPath
     IniRead, VirtualPath, %INI%, Menu, VirtualPath, %VirtualPath%
-    
+
     WinGet, _allWindows, list
     Loop, %_allWindows% {
         _WinID := _allWindows%A_Index%
         WinGetClass, _thisClass, ahk_id %_WinID%
 
-        if (_thisClass == "CabinetWClass")    
+        if (_thisClass == "CabinetWClass")
             GetWINpaths(_WinID)
-        if (_thisClass == "ThunderRT6FormDC")     
+        if (_thisClass == "ThunderRT6FormDC")
             GetXYpaths(_WinID)
-        if (_thisClass == "dopus.lister")             
+        if (_thisClass == "dopus.lister")
             GetDOPUSPaths(_WinID)
-        if (_thisClass == "TTOTAL_CMD")    
+        if (_thisClass == "TTOTAL_CMD")
             GetTCPaths(_WinID)
-   
-   } 
+
+   }
 }
-        
+
 

--- a/Libs/Log.ahk
+++ b/Libs/Log.ahk
@@ -1,6 +1,6 @@
 LogError(_error) {
     global ERRORS, ScriptName
-    
+
     ; generate call stack
     _stack := ""
 	Loop {
@@ -8,17 +8,17 @@ LogError(_error) {
         _call := _e.What
 		if (_call == offset)
 			break
-            
+
 		_stack := _call " > " _stack
 	}
-    
+
     ; Log
     _what := _error.What
     _msg  := _error.Message
     FormatTime, _time,, Time
     FileAppend, % _time "    [" _stack _what "]    " _msg "    " _error.Extra "`n", % ERRORS
-    
-    TrayTip, % ScriptName ": " _what " error", % _msg,, 0x2 
+
+    TrayTip, % ScriptName ": " _what " error", % _msg,, 0x2
     Return true
 }
 OnError("LogError")
@@ -30,8 +30,8 @@ LogHeader() {
 
     FileAppend, Contains only %ScriptName% errors! `n, % ERRORS
     FileAppend, Report about error: https://github.com/JoyHak/QuickSwitch/issues/new?template=bug-report.yaml `n, % ERRORS
-    FileAppend, AHK %A_AhkVersion% `n, % ERRORS    
-        
+    FileAppend, AHK %A_AhkVersion% `n, % ERRORS
+
     _reg := "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion"
     RegRead, _OSname, % _reg, ProductName
     RegRead, _OSversion, % _reg, DisplayVersion
@@ -42,33 +42,33 @@ LogHeader() {
 LogInfo() {
     ; Info about current launched script/compiled app
     global ERRORS
-    
+
     FileAppend, `n--------`n`n, % ERRORS
     /*@Ahk2Exe-Keep
         FileAppend, Script is compiled by %A_UserName% `n, % ERRORS
-        
+
         FileGetVersion, _ver, % A_ScriptFullPath
         FileAppend, Version: %_ver% `n`n, % ERRORS
     */
     _bit  := A_PtrSize * 8
     _arch := A_Is64bitOS ? "64-bit" : "32-bit"
-    FileAppend, %_bit%-bit script for %_arch% system `n`n, % ERRORS 
+    FileAppend, %_bit%-bit script for %_arch% system `n`n, % ERRORS
 }
 
 ValidateLog() {
     global INI, ERRORS, ScriptName
-    
-    if FileExist(ERRORS) { 
+
+    if FileExist(ERRORS) {
         ; Clean log
         FileGetSize, _size, % ERRORS, K
         if (_size > 30) {
             FileDelete, % ERRORS
             Sleep, 500
-        }    
+        }
     }
-    if !FileExist(ERRORS) 
+    if !FileExist(ERRORS)
         LogHeader()
-    
+
     ; does the cur. dir. match the dir. of the script that previously created this log?
     IniRead, _lastPath, % INI, App, LastPath
     _curPath := A_ScriptFullPath

--- a/Libs/MenuSettings.ahk
+++ b/Libs/MenuSettings.ahk
@@ -1,5 +1,5 @@
 /*
-    This menu allows you to change global variables through the GUI.    
+    This menu allows you to change global variables through the GUI.
     All entered/checked values are saved in the INI only when you click OK
 */
 
@@ -8,7 +8,7 @@ ResetSettings() {
     Gui, Destroy
 
     SetDefaultValues()
-    WriteValues() 
+    WriteValues()
     ShowMenuSettings()
 
     Return
@@ -16,7 +16,7 @@ ResetSettings() {
 
 SaveSettings() {
     ; Read current GUI (global) values
-    Gui, Submit  
+    Gui, Submit
     WriteValues()
     ValidateAutoStartup()
     Return
@@ -25,16 +25,16 @@ SaveSettings() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ToggleShortPath() {
-;───────────────────────────────────────────────────────────────────────────── 
+;─────────────────────────────────────────────────────────────────────────────
     ; Hide or display additional options
     global
-    
-    Gui, Submit, NoHide   
+
+    Gui, Submit, NoHide
     if (ShortPath)
         GuiControl,, ShortPath, Show short path, indicate as:
-    else 
+    else
         GuiControl,, ShortPath, Show short path
-    
+
     GuiControl, Show%ShortPath%, CutFromEnd
     GuiControl, Show%ShortPath%, ShowDriveLetter
     GuiControl, Show%ShortPath%, DirsCount
@@ -52,73 +52,73 @@ ToggleShortPath() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ShowMenuSettings() {
-;───────────────────────────────────────────────────────────────────────────── 
+;─────────────────────────────────────────────────────────────────────────────
 
     /*
-        References to global variables are being used. 
-        If possible, it would be advisable to avoid using 
-        references to local variables and creating new ones. 
-        Otherwise, in order to preserve their values, 
-        it may be necessary to consider the synergy of many new functions, 
-        the development of which will require careful thought!   
-    */ 
-    global 
+        References to global variables are being used.
+        If possible, it would be advisable to avoid using
+        references to local variables and creating new ones.
+        Otherwise, in order to preserve their values,
+        it may be necessary to consider the synergy of many new functions,
+        the development of which will require careful thought!
+    */
+    global
 
     LastMenuItem := A_ThisMenuItem
     FromSettings := true
-    
+
     Gui, Font,,%MainFont%
     Gui, Color, %GuiColor%, %GuiColor%
-       
-    ; LEFT ALIGNED TEXT					
-    ;				type		coordinates		vVARIABLE  gGOTO							title                                                 
+
+    ; LEFT ALIGNED TEXT
+    ;				type		coordinates		vVARIABLE  gGOTO							title
     Gui, 	Add, 	Checkbox, 	x12 y+20        vShowDriveLetter checked%ShowDriveLetter%,  Show &drive letter
     Gui, 	Add, 	Checkbox, 					vCutFromEnd checked%CutFromEnd%, 			&Cut from the end
-    
+
     ; Section here is anchor YS pos for right aligned fields
     ; After this block edits will appear starting from this YS pos
-    Gui, 	Add, 	Text, 		        	    vDirNameLengthText Section,				    Length of &dir names	    
-    Gui, 	Add, 	Text, 		    y+13        vDirsCountText,						        Number of &dirs displayed		   
-    Gui, 	Add, 	Text, 		    y+13        vPathSeparatorText,						    P&ath separator			       
-    
-    Gui, 	Add, 	Checkbox,       y+10        vShortPath gToggleShortPath checked%ShortPath%, 	Show short path, indicate as:											  
-    Gui, 	Add, 	Checkbox, 	        		vVirtualPath checked%VirtualPath%, 			Show &virtual path	
-   
-    Gui, 	Add, 	Text, 		    y+20		,											Menu &backgroud color (HEX)                            
+    Gui, 	Add, 	Text, 		        	    vDirNameLengthText Section,				    Length of &dir names
+    Gui, 	Add, 	Text, 		    y+13        vDirsCountText,						        Number of &dirs displayed
+    Gui, 	Add, 	Text, 		    y+13        vPathSeparatorText,						    P&ath separator
+
+    Gui, 	Add, 	Checkbox,       y+10        vShortPath gToggleShortPath checked%ShortPath%, 	Show short path, indicate as:
+    Gui, 	Add, 	Checkbox, 	        		vVirtualPath checked%VirtualPath%, 			Show &virtual path
+
+    Gui, 	Add, 	Text, 		    y+20		,											Menu &backgroud color (HEX)
     Gui, 	Add, 	Text, 		    y+13		,											Dialogs background &color (HEX)
-    
-            
-    ; LEFT ALIGNED CHECKBOXES		
+
+
+    ; LEFT ALIGNED CHECKBOXES
     Gui, 	Add, 	CheckBox, 	xs y+20         vOpenMenu  		checked%OpenMenu%, 			&Always open Menu if AutoSwitch disabled
     Gui, 	Add, 	CheckBox, 					vReDisplayMenu  checked%ReDisplayMenu%, 	Show Menu a&fter leaving settings
     Gui, 	Add, 	CheckBox, 					vPathNumbers	checked%PathNumbers%,		&Path numbers with shortcuts 1-0 (10)
-            
- 
-    ; RIGHT ALIGNED FIELDS	
+
+
+    ; RIGHT ALIGNED FIELDS
     ; Start from first text YS pos
     local edit   := "w63 r1 Limit6 -Wrap"
     Gui, 	Add, 	Edit,   ys-6 %edit%         vDirNameLength, 						    %DirNameLength%
     Gui, 	Add, 	Edit, 	y+4  %edit% 	    vDirsCount, 								%DirsCount%
     Gui, 	Add, 	Edit, 	y+4  %edit% 	    vPathSeparator, 							%PathSeparator%
     Gui, 	Add, 	Edit, 	y+4  %edit% 	    vShortNameIndicator, 						%ShortNameIndicator%
-    
+
     Gui, 	Add, 	Edit, 	y+30 %edit% 	    vMenuColor, 								%MenuColor%
     Gui, 	Add, 	Edit, 	y+4  %edit% 	    vGuiColor, 				    				%GuiColor%
-    
-    
-    ; hidden default button used for accepting {Enter} to leave GUI	    
+
+
+    ; hidden default button used for accepting {Enter} to leave GUI
     Gui, 	Add, 	Button, 	w74 xm+12       Default  gSaveSettings, 					&OK
     Gui, 	Add, 	Button, 	wp x+20 yp  	Cancel   gCancel, 							&Cancel
     Gui, 	Add, 	Button, 	wp x+20 yp 		         gResetSettings, 					&Reset
-    
-    
+
+
     ; SETUP AND SHOW GUI
     ; current checkbox state
-    ToggleShortPath() 
-        
+    ToggleShortPath()
+
     ; These dialog coord. are obtained in ShowPathsMenu()
     local Xpos := WinX
-    local Ypos := WinY + 100 
+    local Ypos := WinY + 100
     Gui, Show, AutoSize x%Xpos% y%Ypos%, Menu settings
 
     Return

--- a/Libs/PathsMenu.ahk
+++ b/Libs/PathsMenu.ahk
@@ -1,7 +1,7 @@
-/* 
-    This is the context menu from which you can select the desired path. 
-    Please note that the displayed and actual paths are independent of each other, 
-    which allows you to display anything. 
+/*
+    This is the context menu from which you can select the desired path.
+    Please note that the displayed and actual paths are independent of each other,
+    which allows you to display anything.
 */
 
 ShouldOpen() {
@@ -12,16 +12,16 @@ ShouldOpen() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 AddPathsMenuItems() {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
 
     global VirtualPath, PathNumbers, ShortPath, paths, virtuals
     _paths := VirtualPath ? virtuals : paths
 
     for _index, _path in _paths {
         _display := ""
-        
+
         if PathNumbers
-            _display .= "&" . _index . " " 
+            _display .= "&" . _index . " "
         if ShortPath
             _display .= ShowShortPath(_path)
         else
@@ -35,28 +35,28 @@ AddPathsMenuItems() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 AddPathsMenuSettings() {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
 
     global DialogAction
 
     Menu ContextMenu, Add,
     Menu ContextMenu, Add, Settings, Dummy
     Menu ContextMenu, disable, Settings
-    
+
     Menu ContextMenu, Add, &Allow AutoSwitch, AutoSwitch, Radio
     Menu ContextMenu, Add, Never &here, Never, Radio
     Menu ContextMenu, Add, &Not now, ThisMenu, Radio
-    
+
     ; Activate radiobutton for current setting (depends on INI setting)
     ; Only show AutoSwitchException if AutoSwitch is activated.
-    
+
     if DialogAction
         Menu ContextMenu, Check, &Allow AutoSwitch
     else if !DialogAction
         Menu ContextMenu, Check, Never &here
     else
         Menu ContextMenu, Check, &Not now
-    
+
     ; new GUI added for other settings
     Menu ContextMenu, Add,
     Menu ContextMenu, Add, Menu &settings, ShowMenuSettings
@@ -66,7 +66,7 @@ AddPathsMenuSettings() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 HidePathsMenu() {
-;───────────────────────────────────────────────────────────────────────────── 
+;─────────────────────────────────────────────────────────────────────────────
     global
     Menu ContextMenu, UseErrorLevel  ; Ignore errors
     Menu ContextMenu, Delete         ; Delete previous menu
@@ -75,7 +75,7 @@ HidePathsMenu() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ShowPathsMenu() {
-;─────────────────────────────────────────────────────────────────────────────  
+;─────────────────────────────────────────────────────────────────────────────
     global DialogID, paths, MenuColor
     global WinX, WinY, WinWidth, WinHeight, MenuColor
     global FromSettings := false
@@ -83,15 +83,15 @@ ShowPathsMenu() {
 
     ; Get dialog position (also used for settings menu positon)
     WinGetPos, WinX, WinY, WinWidth, WinHeight, ahk_id %DialogID%
-    if paths.Count() {     
+    if paths.Count() {
         AddPathsMenuItems()
         AddPathsMenuSettings()
 
         Menu ContextMenu, Color, %MenuColor%
-        Menu ContextMenu, Show, 0, 100        
-        HidePathsMenu()       
+        Menu ContextMenu, Show, 0, 100
+        HidePathsMenu()
 
-    } 
+    }
     Return
 }
 

--- a/Libs/Values.ahk
+++ b/Libs/Values.ahk
@@ -23,42 +23,42 @@ SetDefaultValues() {
     global OpenMenu                  := 1
     global ReDisplayMenu             := 1
     global PathNumbers               := 0
-    
+
     global ShortPath                 := 0
-    global VirtualPath 		         := 0  
-    global ShowDriveLetter 	         := 0 
-    global CutFromEnd 		         := 1  
-    global DirsCount                 := 3    
-    global DirNameLength             := 20  
-                                     
+    global VirtualPath 		         := 0
+    global ShowDriveLetter 	         := 0
+    global CutFromEnd 		         := 1
+    global DirsCount                 := 3
+    global DirNameLength             := 20
+
     global PathSeparator             := "/"
     global ShortNameIndicator        := ".."
-    
+
     ; use system default
     global GuiColor                  := ""
     global MenuColor                 := ""
-    
-    Return    
+
+    Return
 }
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
-WriteValues() { 
-;─────────────────────────────────────────────────────────────────────────────     
-    /*     
+WriteValues() {
+;─────────────────────────────────────────────────────────────────────────────
+    /*
         The status of the checkboxes from the settings menu is writed immediately
         Strings and colors from fields are checked before writing.
-        file, section, param name, global var and its value reference 
-        are identical to those in ReadValues() 
+        file, section, param name, global var and its value reference
+        are identical to those in ReadValues()
     */
     global
 
     try {
         ; 			value						INI name	section		param name
-        IniWrite, 	%AutoStartup%, 				%INI%, 		App, 		AutoStartup    
-        IniWrite, 	%MainIcon%, 			    %INI%, 		App, 	    MainIcon    
-        IniWrite, 	%MainFont%, 			    %INI%, 		App, 	    MainFont    
-        IniWrite, 	%RestartWhere%, 			%INI%, 		App, 	    RestartWhere    
+        IniWrite, 	%AutoStartup%, 				%INI%, 		App, 		AutoStartup
+        IniWrite, 	%MainIcon%, 			    %INI%, 		App, 	    MainIcon
+        IniWrite, 	%MainFont%, 			    %INI%, 		App, 	    MainFont
+        IniWrite, 	%RestartWhere%, 			%INI%, 		App, 	    RestartWhere
         IniWrite, 	%OpenMenu%, 				%INI%, 		Menu, 		OpenMenu
         IniWrite, 	%ShortPath%, 				%INI%, 		Menu, 		ShortPath
         IniWrite, 	%ReDisplayMenu%, 			%INI%, 		Menu, 		ReDisplayMenu
@@ -66,21 +66,21 @@ WriteValues() {
         IniWrite, 	%VirtualPath%, 				%INI%, 		Menu, 		VirtualPath
         IniWrite, 	%ShowDriveLetter%, 			%INI%, 		Menu, 		ShowDriveLetter
         IniWrite, 	%CutFromEnd%, 				%INI%, 		Menu, 		CutFromEnd
-        
-        Menu, Tray, Icon, %MainIcon% 
+
+        Menu, Tray, Icon, %MainIcon%
     } catch {
         LogError(Exception(INI . " write", "Failed to write values to the configuration", "Maybe INI file is not created?"))
     }
 
     ValidateWriteInteger(DirsCount, 		"DirsCount")
     ValidateWriteInteger(DirNameLength, 	"DirNameLength")
-    
+
     ValidateWriteString(PathSeparator, 		"PathSeparator")
     ValidateWriteString(ShortNameIndicator, "ShortNameIndicator")
-    
+
     ValidateWriteKey(MainKey, 		"MainKey",      "ShowPathsMenu",    "Off")
     ValidateWriteKey(RestartKey, 	"RestartKey",   "RestartApp",       "On")
-    
+
     ValidateWriteColor(GuiColor, 	"GuiColor")
     ValidateWriteColor(MenuColor, 	"MenuColor")
 
@@ -90,13 +90,13 @@ WriteValues() {
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ReadValues() {
-;───────────────────────────────────────────────────────────────────────────── 
-    /*     
+;─────────────────────────────────────────────────────────────────────────────
+    /*
         read values from INI
         the current value of global variables is set at the top of the script
         so it is passed to IniRead as "default value".
-        file, section, param name, global var and its value reference are identical 
-        to those in WriteValues() 
+        file, section, param name, global var and its value reference are identical
+        to those in WriteValues()
     */
     global
 
@@ -107,7 +107,7 @@ ReadValues() {
     IniRead, 	MainKey, 				    %INI%,		App, 		MainKey, 	                %MainKey%
     IniRead, 	RestartKey, 				%INI%,		App, 		RestartKey, 	            %RestartKey%
     IniRead, 	RestartWhere, 				%INI%,		App, 		RestartWhere, 	            %RestartWhere%
-    
+
     IniRead, 	OpenMenu, 					%INI%,		Menu, 		OpenMenu, 	                %OpenMenu%
     IniRead, 	ShortPath, 					%INI%,		Menu, 		ShortPath,      	        %ShortPath%
     IniRead, 	ReDisplayMenu, 				%INI%,		Menu, 		ReDisplayMenu,  	        %ReDisplayMenu%
@@ -115,33 +115,33 @@ ReadValues() {
     IniRead, 	VirtualPath, 				%INI%,		Menu, 		VirtualPath, 				%VirtualPath%
     IniRead, 	ShowDriveLetter, 			%INI%,		Menu, 		ShowDriveLetter, 			%ShowDriveLetter%
     IniRead, 	CutFromEnd, 				%INI%,		Menu, 		CutFromEnd, 				%CutFromEnd%
-                    
+
     IniRead, 	DirsCount, 				    %INI%,		Menu, 		DirsCount,      	    	%DirsCount%
     IniRead, 	DirNameLength, 			    %INI%,		Menu, 		DirNameLength,      	    %DirNameLength%
-    
+
     IniRead, 	PathSeparator, 				%INI%,		Menu, 		PathSeparator,      	    %PathSeparator%
     IniRead, 	ShortNameIndicator, 	 	%INI%,		Menu, 		ShortNameIndicator,      	%ShortNameIndicator%
-                
+
     IniRead, 	GuiColor, 					%INI%,		Colors, 	GuiColor, 				    %A_Space%
     IniRead, 	MenuColor, 					%INI%,		Colors, 	MenuColor, 				    %A_Space%
-    
+
     Return
 }
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ValidateWriteKey(_new, _paramName, _funcObj, _state) {       ; bind key
-;─────────────────────────────────────────────────────────────────────────────     
+;─────────────────────────────────────────────────────────────────────────────
     global INI
-    
+
     try {
         Hotkey, % _new, % _funcObj, % _state                 ; create hotkey
         IniWrite, % _new, % INI, App, % _paramName           ; save
     } catch _error {
         LogError(_error)
         Return
-    }  
-    IniRead, _old, % INI, App, % _paramName, % _new          ; remove old if exist    
+    }
+    IniRead, _old, % INI, App, % _paramName, % _new          ; remove old if exist
     if (_old != _new)
         Hotkey, % _old, Off
 }
@@ -149,19 +149,19 @@ ValidateWriteKey(_new, _paramName, _funcObj, _state) {       ; bind key
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ValidateWriteInteger(_new, _paramName) {    ; integer only
-;─────────────────────────────────────────────────────────────────────────────     
+;─────────────────────────────────────────────────────────────────────────────
     global INI
-    
-    if _new is Integer 
+
+    if _new is Integer
         IniWrite, % _new, % INI, Menu, % _paramName
-    else 
+    else
         throw Exception(_new " is not an integer for the " _paramName " parameter", _paramName)
 }
 
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ValidateWriteColor(_color, _paramName) {    ; valid HEX / empty value only
-;───────────────────────────────────────────────────────────────────────────── 
+;─────────────────────────────────────────────────────────────────────────────
     global INI
 
     _matchPos := RegExMatch(_color, "i)[a-f0-9]{6}$")
@@ -176,9 +176,9 @@ ValidateWriteColor(_color, _paramName) {    ; valid HEX / empty value only
 ;─────────────────────────────────────────────────────────────────────────────
 ;
 ValidateWriteString(_new, _paramName) {     ; format to string
-;─────────────────────────────────────────────────────────────────────────────     
+;─────────────────────────────────────────────────────────────────────────────
     global INI
-    
-    _result := Format("{}", _new)    
+
+    _result := Format("{}", _new)
     IniWrite, % _result, % INI, Menu, % _paramName
 }

--- a/QuickSwitch-1.2.ahk
+++ b/QuickSwitch-1.2.ahk
@@ -1,3 +1,6 @@
+;@Ahk2Exe-Base C:\Program Files\AutoHotkey\v1.1.37.02\AutoHotkeyU32.exe, %A_ScriptDir%\Releases\%A_ScriptName~\.ahk%-x32.exe
+;@Ahk2Exe-Base C:\Program Files\AutoHotkey\v1.1.37.02\AutoHotkeyU64.exe, %A_ScriptDir%\Releases\%A_ScriptName~\.ahk%-x64.exe
+
 ;@Ahk2Exe-SetVersion %A_ScriptName~[^\d\.]+%
 ;@Ahk2Exe-SetMainIcon QuickSwitch.ico
 ;@Ahk2Exe-SetDescription Quickly Switch to the path from any file manager.
@@ -9,15 +12,15 @@
 ;@Ahk2Exe-PostExec "C:\Program Files\7-Zip\7zG.exe" a "%A_ScriptDir%\Releases\%U_name%".zip -tzip -sae -- "%A_ScriptDir%\%U_name%.ahk" "%A_ScriptDir%\Libs" "%A_ScriptDir%\QuickSwitch.ico",, A_ScriptDir
 
 /*
-    Modification by Rafaello: 
+    Modification by Rafaello:
     https://github.com/JoyHak/QuickSwitch
-    
-    Based on v0.5dw9a by NotNull, DaWolfi and Tuska: 
+
+    Based on v0.5dw9a by NotNull, DaWolfi and Tuska:
     https://www.voidtools.com/forum/viewtopic.php?f=2&t=9881
-    
-    
-    This is the main file that is waiting for the dialog window to appear. 
-    Then initializes the menu display. 
+
+
+    This is the main file that is waiting for the dialog window to appear.
+    Then initializes the menu display.
     The hotkey is declared once and linked to the ShowPathsMenu().
 */
 
@@ -25,10 +28,11 @@
 #SingleInstance force
 #NoEnv
 #Warn
+
 FileEncoding, UTF-8
 SetWorkingDir %A_ScriptDir%
 
-global ScriptName := "QuickSwitch" 
+global ScriptName := "QuickSwitch"
 global INI := ScriptName ".ini"
 global ERRORS := "Errors.log"
 
@@ -50,9 +54,9 @@ ValidateLog()
 ValidateAutoStartup()
 
 ValidateWriteKey(MainKey, 		"MainKey",      "ShowPathsMenu",    "Off")
-ValidateWriteKey(RestartKey, 	"RestartKey",   "RestartApp",       "On") 
-Menu, Tray, UseErrorLevel 
-Menu, Tray, Icon, %MainIcon% 
+ValidateWriteKey(RestartKey, 	"RestartKey",   "RestartApp",       "On")
+Menu, Tray, UseErrorLevel
+Menu, Tray, Icon, %MainIcon%
 
 ; Wait for dialog
 Loop {
@@ -62,10 +66,10 @@ Loop {
 
     ; if there is any GUI left from previous calls....
     Gui, Destroy
-    
+
     IniRead, MainKey, %INI%, App, MainKey
-    if FileDialog 
-    {                                                       ; This is a supported dialog    
+    if FileDialog
+    {                                                       ; This is a supported dialog
         GetPaths()
         WinGet, ahk_exe, ProcessName, ahk_id %DialogID%
         WinGetTitle, window_title, ahk_id %DialogID%
@@ -73,14 +77,14 @@ Loop {
 
         ; Check if FingerPrint entry is already in INI, so we know what to do.
         IniRead, DialogAction, %INI%, Dialogs, %FingerPrint%, 0
-        if (DialogAction == 1) {                                           ; ======= AutoSwitch ==        
+        if (DialogAction == 1) {                                           ; ======= AutoSwitch ==
             AutoSwitch()
-        } else if (DialogAction == 0) {                                    ; ======= Never here ==        
+        } else if (DialogAction == 0) {                                    ; ======= Never here ==
             if ShouldOpen() {
                 ShowPathsMenu()         ; AutoOpenMenu only
             }
         }
-        else if ShouldOpen() {                                             ; ======= Show Menu ==        
+        else if ShouldOpen() {                                             ; ======= Show Menu ==
             ShowPathsMenu()             ; hotkey or AutoOpenMenu
         }
 
@@ -94,15 +98,14 @@ Loop {
     Sleep, 100
     WinWaitNotActive
 
-    ; Clean up        
-    Hotkey, %MainKey%, Off    
+    ; Clean up
+    Hotkey, %MainKey%, Off
     ahk_exe         := ""
     window_title    := ""
     DialogAction    := ""
     DialogID        := ""
-    DialogType      := ""
-    
+
 }   ; End of continuous WinWaitActive loop
 
-LogError(Exception("Main menu error", "An error occurred while waiting for the file dialog to appear. Restart the app manually", "End of continuous WinWaitActive loop in main file"))
+LogError(Exception("Main menu", "An error occurred while waiting for the file dialog to appear. Restart the app manually", "End of continuous WinWaitActive loop in main file"))
 ExitApp


### PR DESCRIPTION
- Cleaned up the code by removing an outdated global variable that was no longer in use.
- Adjusted the .gitignore file 
- Replaced the use of MsgBox with logging for better debugging
- Included an additional missing `_pathSet` flag declaration to enhance functionality.
- Removed outdated comments to improve code readability
- Moved `ControlFocus` and `ControlSend` to separate lines 
- Improved controls checking and modified the menu visibility to hide it from windows, popus and controls that are not file dialogs 
- Trimmed trailing spaces to decrease codebase size